### PR TITLE
Feature/http interface implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,11 @@
             <version>${spring.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webflux</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
             <version>${spring-boot.version}</version>

--- a/src/main/java/com/github/mjmlconverter/client/MjmlClient.java
+++ b/src/main/java/com/github/mjmlconverter/client/MjmlClient.java
@@ -5,8 +5,18 @@ import com.github.mjmlconverter.dto.MjmlRequest;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.service.annotation.PostExchange;
 
+/**
+ * Client interface for interacting with the MJML rendering API.
+ * This interface provides methods to convert MJML templates into responsive HTML.
+ */
 public interface MjmlClient {
 
+    /**
+     * Sends a request to render an MJML template into responsive HTML.
+     *
+     * @param mjmlRequest Contains the MJML content to be rendered.
+     * @return HtmlResponse Contains the resulting HTML after rendering.
+     */
     @PostExchange(url = "/render")
     HtmlResponse render(@RequestBody MjmlRequest mjmlRequest);
 }

--- a/src/main/java/com/github/mjmlconverter/client/MjmlClient.java
+++ b/src/main/java/com/github/mjmlconverter/client/MjmlClient.java
@@ -1,0 +1,12 @@
+package com.github.mjmlconverter.client;
+
+import com.github.mjmlconverter.dto.HtmlResponse;
+import com.github.mjmlconverter.dto.MjmlRequest;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.service.annotation.PostExchange;
+
+public interface MjmlClient {
+
+    @PostExchange(url = "/render")
+    HtmlResponse render(@RequestBody MjmlRequest mjmlRequest);
+}

--- a/src/main/java/com/github/mjmlconverter/config/MjmlClientConfig.java
+++ b/src/main/java/com/github/mjmlconverter/config/MjmlClientConfig.java
@@ -13,15 +13,27 @@ import org.springframework.web.reactive.function.client.support.WebClientAdapter
 import org.springframework.web.service.invoker.HttpServiceProxyFactory;
 import reactor.core.publisher.Mono;
 
+
+/**
+ * Configuration class responsible for setting up the MJML client with necessary configurations
+ * to communicate with the MJML API.
+ *
+ * It integrates Spring's WebClient with the MJML service to render MJML templates into HTML.
+ */
 @Configuration
 @RequiredArgsConstructor
 @EnableConfigurationProperties(MjmlProperties.class)
 public class MjmlClientConfig {
 
+    private static final String MJML_API_ENDPOINT = "https://api.mjml.io/v1";
     private final MjmlProperties properties;
 
-    private static final String MJML_API_ENDPOINT = "https://api.mjml.io/v1";
-
+    /**
+     * Creates and configures the MJML client bean for rendering MJML templates.
+     * It initializes a WebClient with default headers, error handling, and the MJML API endpoint.
+     *
+     * @return The configured MjmlClient bean ready to communicate with the MJML API.
+     */
     @Bean
     public MjmlClient mjmlClient() {
         WebClient client = WebClient.builder()

--- a/src/main/java/com/github/mjmlconverter/config/MjmlClientConfig.java
+++ b/src/main/java/com/github/mjmlconverter/config/MjmlClientConfig.java
@@ -1,0 +1,39 @@
+package com.github.mjmlconverter.config;
+
+import com.github.mjmlconverter.client.MjmlClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.support.WebClientAdapter;
+import org.springframework.web.service.invoker.HttpServiceProxyFactory;
+import reactor.core.publisher.Mono;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableConfigurationProperties(MjmlProperties.class)
+public class MjmlClientConfig {
+
+    private final MjmlProperties properties;
+
+    private static final String MJML_API_ENDPOINT = "https://api.mjml.io/v1";
+
+    @Bean
+    public MjmlClient mjmlClient() {
+        WebClient client = WebClient.builder()
+                                   .defaultHeaders(httpHeaders -> {
+                                       httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+                                       httpHeaders.setBasicAuth(properties.getAppId(), properties.getAppSecret());
+                                   })
+                                   .defaultStatusHandler(HttpStatusCode::isError, response ->
+                                                                                          Mono.just(new RuntimeException("Error from MJML API: " + response.bodyToMono(String.class))))
+                                   .baseUrl(MJML_API_ENDPOINT)
+                                   .build();
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(WebClientAdapter.forClient(client))
+                                                  .build();
+        return factory.createClient(MjmlClient.class);
+    }
+}

--- a/src/main/java/com/github/mjmlconverter/config/MjmlClientConfig.java
+++ b/src/main/java/com/github/mjmlconverter/config/MjmlClientConfig.java
@@ -1,6 +1,7 @@
 package com.github.mjmlconverter.config;
 
 import com.github.mjmlconverter.client.MjmlClient;
+import com.github.mjmlconverter.exception.MjmlConversionException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -29,7 +30,7 @@ public class MjmlClientConfig {
                                        httpHeaders.setBasicAuth(properties.getAppId(), properties.getAppSecret());
                                    })
                                    .defaultStatusHandler(HttpStatusCode::isError, response ->
-                                                                                          Mono.just(new RuntimeException("Error from MJML API: " + response.bodyToMono(String.class))))
+                                                                                          Mono.just(new MjmlConversionException("Error from MJML API: " + response.bodyToMono(String.class))))
                                    .baseUrl(MJML_API_ENDPOINT)
                                    .build();
         HttpServiceProxyFactory factory = HttpServiceProxyFactory.builder(WebClientAdapter.forClient(client))

--- a/src/main/java/com/github/mjmlconverter/config/MjmlConverterAutoConfiguration.java
+++ b/src/main/java/com/github/mjmlconverter/config/MjmlConverterAutoConfiguration.java
@@ -1,6 +1,7 @@
 package com.github.mjmlconverter.config;
 
 import com.github.mjmlconverter.builder.MjmlRequestBuilder;
+import com.github.mjmlconverter.client.MjmlClient;
 import com.github.mjmlconverter.converter.MjmlConverter;
 import com.github.mjmlconverter.converter.MjmlConverterImpl;
 import com.github.mjmlconverter.template.TemplateCompiler;
@@ -8,24 +9,21 @@ import com.github.mjmlconverter.template.TemplateCompilerImpl;
 import com.github.mjmlconverter.template.TemplateLoader;
 import com.github.mjmlconverter.template.TemplateLoaderImpl;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ResourceLoader;
-import org.springframework.web.client.RestTemplate;
 
 /**
  * Spring Boot auto-configuration class for the MJML converter components.
  * This class contains bean definitions that are conditionally created only if they don't already exist in the context.
  */
 @Configuration
-@EnableConfigurationProperties(MjmlProperties.class)
 public class MjmlConverterAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public MjmlConverter mjmlConverter(MjmlProperties properties, RestTemplate restTemplate) {
-        return new MjmlConverterImpl(properties, restTemplate);
+    public MjmlConverter mjmlConverter(MjmlClient mjmlClient) {
+        return new MjmlConverterImpl(mjmlClient);
     }
 
     @Bean
@@ -44,11 +42,5 @@ public class MjmlConverterAutoConfiguration {
     @ConditionalOnMissingBean
     public TemplateLoader templateLoader(ResourceLoader resourceLoader) {
         return new TemplateLoaderImpl(resourceLoader);
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
-    public RestTemplate restTemplate() {
-        return new RestTemplate();
     }
 }

--- a/src/main/java/com/github/mjmlconverter/converter/MjmlConverter.java
+++ b/src/main/java/com/github/mjmlconverter/converter/MjmlConverter.java
@@ -15,5 +15,4 @@ public interface MjmlConverter {
      * @return The converted HTML response.
      */
     HtmlResponse convert(MjmlRequest mjmlRequest);
-
 }

--- a/src/main/java/com/github/mjmlconverter/converter/MjmlConverterImpl.java
+++ b/src/main/java/com/github/mjmlconverter/converter/MjmlConverterImpl.java
@@ -1,19 +1,11 @@
 package com.github.mjmlconverter.converter;
 
-import com.github.mjmlconverter.config.MjmlProperties;
+import com.github.mjmlconverter.client.MjmlClient;
 import com.github.mjmlconverter.dto.HtmlResponse;
 import com.github.mjmlconverter.dto.MjmlRequest;
 import com.github.mjmlconverter.exception.MjmlConversionException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.client.HttpServerErrorException;
-import org.springframework.web.client.ResourceAccessException;
-import org.springframework.web.client.RestTemplate;
 
 /**
  * Implementation of the MjmlConverter interface, converting MJML to HTML using the MJML API.
@@ -22,11 +14,7 @@ import org.springframework.web.client.RestTemplate;
 @RequiredArgsConstructor
 public class MjmlConverterImpl implements MjmlConverter {
 
-    // Endpoint URL for the MJML API.
-    private static final String MJML_API_ENDPOINT = "https://api.mjml.io/v1/render";
-
-    private final MjmlProperties properties;
-    private final RestTemplate restTemplate;
+    private final MjmlClient mjmlClient;
 
     /**
      * Converts the provided MJML content to HTML.
@@ -37,37 +25,6 @@ public class MjmlConverterImpl implements MjmlConverter {
      */
     @Override
     public HtmlResponse convert(MjmlRequest mjmlRequest) {
-        HttpEntity<MjmlRequest> entity = createHttpEntity(mjmlRequest);
-
-        // Attempt to send the MJML request and get the HTML response.
-        try {
-            return restTemplate.postForObject(MJML_API_ENDPOINT, entity, HtmlResponse.class);
-        } catch (HttpClientErrorException | HttpServerErrorException e) {
-            // Handle 4xx/5xx errors.
-            throw new MjmlConversionException("Error from MJML API: " + e.getResponseBodyAsString(), e);
-        } catch (ResourceAccessException e) {
-            // Handle connection errors.
-            throw new MjmlConversionException("Unable to connect to MJML API.", e);
-        } catch (HttpMessageNotReadableException e) {
-            // Handle deserialization errors.
-            throw new MjmlConversionException("Unexpected response from MJML API.", e);
-        } catch (Exception e) {
-            // Catch-all for other exceptions.
-            throw new MjmlConversionException("Unknown error during MJML conversion.", e);
-        }
-    }
-
-    /**
-     * Prepares the HTTP entity for MJML API request with appropriate headers and body.
-     *
-     * @param mjmlRequest MJML content for the request body.
-     * @return Configured HttpEntity instance.
-     */
-    private HttpEntity<MjmlRequest> createHttpEntity(MjmlRequest mjmlRequest) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-        headers.setBasicAuth(properties.getAppId(), properties.getAppSecret());
-
-        return new HttpEntity<MjmlRequest>(mjmlRequest, headers);
+        return mjmlClient.render(mjmlRequest);
     }
 }

--- a/src/main/java/com/github/mjmlconverter/dto/HtmlResponse.java
+++ b/src/main/java/com/github/mjmlconverter/dto/HtmlResponse.java
@@ -16,5 +16,4 @@ public class HtmlResponse {
 
     // The converted HTML content.
     private String html;
-
 }

--- a/src/main/java/com/github/mjmlconverter/dto/MjmlRequest.java
+++ b/src/main/java/com/github/mjmlconverter/dto/MjmlRequest.java
@@ -14,5 +14,4 @@ public class MjmlRequest {
 
     // The MJML content to be converted.
     private String mjml;
-
 }

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,2 @@
 com.github.mjmlconverter.config.MjmlConverterAutoConfiguration
+com.github.mjmlconverter.config.MjmlClientConfig


### PR DESCRIPTION
### Pull Request: Refactor MJML Converter to use HTTP Interface based MjmlClient

#### Overview:
This pull request aims to refactor the `MjmlConverter` library by transitioning from a `RestTemplate`-based approach to a more modern `HTTP Interface` based approach, encapsulated within the `MjmlClient` interface.

#### Key Changes:

1. **MjmlConverter Implementation**:
   - The `MjmlConverterImpl` has been streamlined to use the `MjmlClient` for converting MJML content to HTML.
   - Exception handling has been moved to the WebClient configuration, providing cleaner and more centralized error handling.

2. **MjmlClient Configuration**:
   - Introduced a new configuration class `MjmlClientConfig` which sets up the `WebClient` with necessary default headers, error handlers, and the MJML API endpoint.
   - Leveraged the `HttpServiceProxyFactory` to create a client proxy for the MJML service.

3. **MjmlConverterAutoConfiguration**:
   - Removed the `RestTemplate` bean as it's no longer required.
   - Updated the `MjmlConverter` bean to depend on the new `MjmlClient`.

#### Benefits:
- **Cleaner Code**: Centralizing the error handling and client setup in one place provides a more maintainable and clear codebase.
- **Flexibility**: The new structure with `MjmlClient` offers greater flexibility for potential future enhancements, like incorporating client-side caching, retry mechanisms, etc.
